### PR TITLE
Add MultiGPUs context manager

### DIFF
--- a/chapter_computational-performance/auto-parallelism.ipynb
+++ b/chapter_computational-performance/auto-parallelism.ipynb
@@ -59,8 +59,13 @@
     "def run(x):\n",
     "    return [x.mm(x) for _ in range(50)]\n",
     "\n",
-    "with d2l.MultiGPUs():\n",
-    "    x_gpu1 = torch.rand(size=(4000, 4000), device=devices[0])\n",
+    "x_gpu1 = torch.rand(size=(4000, 4000), device=devices[0])\n",
+    "\n",
+    "if len(devices) < 2:\n",
+    "    warnings.warn(f'Code is skipped because at least two '\n",
+    "                  f'GPUs are required but {len(devices)} GPU '\n",
+    "                  f'is found.')\n",
+    "else:\n",
     "    x_gpu2 = torch.rand(size=(4000, 4000), device=devices[1])"
    ]
   },
@@ -91,7 +96,11 @@
     }
    ],
    "source": [
-    "with d2l.MultiGPUs():\n",
+    "if len(devices) < 2:\n",
+    "    warnings.warn(f'Code is skipped because at least two '\n",
+    "                  f'GPUs are required but {len(devices)} GPU '\n",
+    "                  f'is found.')\n",
+    "else:\n",
     "    run(x_gpu1)\n",
     "    run(x_gpu2)  # Warm-up all devices\n",
     "    torch.cuda.synchronize(devices[0])\n",
@@ -132,7 +141,11 @@
     }
    ],
    "source": [
-    "with d2l.MultiGPUs():\n",
+    "if len(devices) < 2:\n",
+    "    warnings.warn(f'Code is skipped because at least two '\n",
+    "                  f'GPUs are required but {len(devices)} GPU '\n",
+    "                  f'is found.')\n",
+    "else:\n",
     "    with d2l.Benchmark('GPU1 & GPU2'):\n",
     "        run(x_gpu1)\n",
     "        run(x_gpu2)\n",

--- a/chapter_computational-performance/multiple-gpus-concise.ipynb
+++ b/chapter_computational-performance/multiple-gpus-concise.ipynb
@@ -1673,7 +1673,11 @@
     }
    ],
    "source": [
-    "with d2l.MultiGPUs():\n",
+    "if len(devices) < 2:\n",
+    "    warnings.warn(f'Code is skipped because at least two '\n",
+    "                  f'GPUs are required but {len(devices)} GPU '\n",
+    "                  f'is found.')\n",
+    "else:\n",
     "    train(net, num_gpus=2, batch_size=512, lr=0.2)"
    ]
   },

--- a/chapter_computational-performance/multiple-gpus.ipynb
+++ b/chapter_computational-performance/multiple-gpus.ipynb
@@ -276,7 +276,12 @@
     }
    ],
    "source": [
-    "with d2l.MultiGPUs():\n",
+    "devices = d2l.try_all_gpus()\n",
+    "if len(devices) < 2:\n",
+    "    warnings.warn(f'Code is skipped because at least two '\n",
+    "                  f'GPUs are required but {len(devices)} GPU '\n",
+    "                  f'is found.')\n",
+    "else:\n",
     "    data = [torch.ones((1, 2), device=d2l.try_gpu(i)) * (i + 1) for i in range(2)]\n",
     "    print('before allreduce:\\n', data[0], '\\n', data[1])\n",
     "    allreduce(data)\n",
@@ -319,7 +324,11 @@
     }
    ],
    "source": [
-    "with d2l.MultiGPUs():\n",
+    "if len(devices) < 2:\n",
+    "    warnings.warn(f'Code is skipped because at least two '\n",
+    "                  f'GPUs are required but {len(devices)} GPU '\n",
+    "                  f'is found.')\n",
+    "else:\n",
     "    data = torch.arange(20).reshape(4, 5)\n",
     "    devices = [torch.device('cuda:0'), torch.device('cuda:1')]\n",
     "    split = nn.parallel.scatter(data, devices)\n",
@@ -1817,7 +1826,11 @@
     }
    ],
    "source": [
-    "with d2l.MultiGPUs():\n",
+    "if len(devices) < 2:\n",
+    "    warnings.warn(f'Code is skipped because at least two '\n",
+    "                  f'GPUs are required but {len(devices)} GPU '\n",
+    "                  f'is found.')\n",
+    "else:\n",
     "    train(num_gpus=2, batch_size=256, lr=0.2)"
    ]
   },

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -437,20 +437,6 @@ def try_all_gpus():
     return devices if devices else [torch.device('cpu')]
 
 
-class MultiGPUs:
-    def __init__(self):
-        self.num_gpus = len(try_all_gpus())
-
-    def __enter__(self):
-        if self.num_gpus < 2:
-            warnings.warn('Code is skipped because at least two '
-                          f'GPUs are required but {self.num_gpus} GPU '
-                          'is found.')
-
-    def __exit__(self, *args):
-        return True
-
-
 # Defined in file: ./chapter_convolutional-neural-networks/conv-layer.md
 def corr2d(X, K):
     """Compute 2D cross-correlation."""


### PR DESCRIPTION
This PR adds a context manager named `MultiGPUs` to suppress errors on Seychelles instances that have less than 2 GPUs.

Note that the class is saved into `d2l` package but without a new small updated release including this functionality the users won't be able to run these because we install d2l=0.17 in the env.yml file.