### PR TITLE
BUG: explicitly move to cpu before plotting

### DIFF
--- a/chapter_computer-vision/kaggle-dog.ipynb
+++ b/chapter_computer-vision/kaggle-dog.ipynb
@@ -432,7 +432,7 @@
     "        measures = f'train loss {metric[0] / metric[1]:.3f}'\n",
     "        if valid_iter is not None:\n",
     "            valid_loss = evaluate_loss(valid_iter, net, devices)\n",
-    "            animator.add(epoch + 1, (None, valid_loss.detach()))\n",
+    "            animator.add(epoch + 1, (None, valid_loss.detach().cpu()))\n",
     "        scheduler.step()\n",
     "    if valid_iter is not None:\n",
     "        measures += f', valid loss {valid_loss:.3f}'\n",


### PR DESCRIPTION
This is a simple fix for the following error issued when running this notebook. 
> TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.

Please DO NOT MERGE this yet. This is weird because the cuda scalar tensor used to work before. I need to find what changed to pin point the root cause. 