### PR TITLE
Update linear-regression-concise.ipynb

### DIFF
--- a/chapter_linear-networks/linear-regression-concise.ipynb
+++ b/chapter_linear-networks/linear-regression-concise.ipynb
@@ -491,7 +491,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "1. If we replace `nn.MSELoss(reduction='sum')` with `nn.MSELoss()`, how can we change the learning rate for the code to behave identically. Why?\n",
+    "1. If we replace `nn.MSELoss()` with `nn.MSELoss(reduction='sum')`, how can we change the learning rate for the code to behave identically. Why?\n",
     "1. Review the PyTorch documentation to see what loss functions and initialization methods are provided. Replace the loss by Huber's loss.\n",
     "1. How do you access the gradient of `net[0].weight`?\n"
    ]


### PR DESCRIPTION
In 3.3.9 Exercises - Exercise 1 for PyTorch.
I think the expression in line 494:
"If we replace  `nn.MSELoss(reduction='sum')` with `nn.MSELoss()`"
is should be replaced with
"If we replace `nn.MSELoss()` with `nn.MSELoss(reduction='sum')`"

Current usage of nn.MSELoss in 8th codeblock in this notebook is already loss = nn.MSELoss()

I also found this issue in these other repositories: d2l-ai/d2l-pytorch-colab, d2l-ai/d2l-pytorch-sagemaker, d2l-ai/d2l-tr, d2l-ai/d2l-ja, d2l-ai/d2l-ko, d2l-ai/d2l-pt.